### PR TITLE
ES5ify our non-transpiled package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,20 @@
-const React = require('react');
+'use strict';
 
-const ansiToJSON = require('ansi-to-json');
+var React = require('react');
+
+var ansiToJSON = require('ansi-to-json');
 
 function ansiJSONtoStyleBundle(ansiBundle) {
-  const style = {};
+  var style = {};
   if (ansiBundle.bg) {
-    style.backgroundColor = `rgb(${ansiBundle.bg})`;
+    style.backgroundColor = 'rgb(' + ansiBundle.bg + ')';
   }
   if (ansiBundle.fg) {
-    style.color = `rgb(${ansiBundle.fg})`;
+    style.color = 'rgb(' + ansiBundle.fg + ')';
   }
   return {
     content: ansiBundle.content,
-    style,
+    style: style
   };
 }
 
@@ -23,7 +25,7 @@ function ansiToInlineStyle(text) {
 function inlineBundleToReact(bundle, key) {
   return React.createElement('span', {
     style: bundle.style,
-    key,
+    key: key
   }, bundle.content);
 }
 
@@ -35,7 +37,7 @@ function Ansi(props) {
 }
 
 Ansi.propTypes = {
-  children: React.PropTypes.string,
+  children: React.PropTypes.string
 };
 
 module.exports = Ansi;


### PR DESCRIPTION
Since we had `const` and the use of string templates yet weren't transpiling the source, this code worked in Firefox, Edge, and Chrome but not Safari (including iOS Safari).

Closes #7 

Chock this up to favoring transpiling by default to ensure you don't introduce something you shouldn't!