### PR TITLE
Remove PropTypes deprecation errors in React 15.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "escape-carriage": "^1.0.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-0"
+    "prop-types": "^15.5.9",
+    "react": "^15.0.0-0"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const PropTypes = require('prop-types');
 const Anser = require('anser');
 const escapeCarriageReturn = require('escape-carriage');
 
@@ -71,7 +72,7 @@ function Ansi(props) {
   return React.createElement(
     'code',
     {},
-    props.linkify 
+    props.linkify
       ? ansiToInlineStyle(props.children)
         .map(linkifyBundle)
         .map(inlineBundleToReact)
@@ -80,7 +81,7 @@ function Ansi(props) {
 }
 
 Ansi.propTypes = {
-  children: React.PropTypes.string,
+  children: PropTypes.string,
 };
 
 module.exports = Ansi;


### PR DESCRIPTION
With React 16 coming up we got a deprecation warning in 15.3 about importing `PropTypes` from it's own package `prop-types`, this will be a breaking change in React 16.

- [x] Remove React 14
- [x] Add prop-types