### PR TITLE
Fix linkify when links are separated by one space

### DIFF
--- a/__tests__/index.spec.tsx
+++ b/__tests__/index.spec.tsx
@@ -163,6 +163,21 @@ describe("Ansi", () => {
     expect(el.childAt(0).children()).toHaveLength(3);
   });
 
+  test("can linkify multiple links one after another", () => {
+    const el = shallow(
+      React.createElement(
+        Ansi,
+        { linkify: true },
+        "www.google.com www.google.com www.google.com"
+      )
+    );
+    expect(el).not.toBeNull();
+    expect(el.text()).toBe("www.google.com www.google.com www.google.com");
+    expect(el.html()).toBe(
+      '<code><span><a href="http://www.google.com" target="_blank">www.google.com</a> <a href="http://www.google.com" target="_blank">www.google.com</a> <a href="http://www.google.com" target="_blank">www.google.com</a></span></code>'
+    );
+  });
+
   describe("useClasses options", () => {
     test("can add the font color class", () => {
       const el = shallow(

--- a/__tests__/index.spec.tsx
+++ b/__tests__/index.spec.tsx
@@ -178,6 +178,21 @@ describe("Ansi", () => {
     );
   });
 
+  test("can handle URLs inside query parameters", () => {
+    const el = shallow(
+      React.createElement(
+        Ansi,
+        { linkify: true },
+        "www.google.com/?q=https://www.google.com"
+      )
+    );
+    expect(el).not.toBeNull();
+    expect(el.text()).toBe("www.google.com/?q=https://www.google.com");
+    expect(el.html()).toBe(
+      '<code><span><a href="http://www.google.com/?q=https://www.google.com" target="_blank">www.google.com/?q=https://www.google.com</a></span></code>'
+    );
+  });
+
   describe("useClasses options", () => {
     test("can add the font color class", () => {
       const el = shallow(

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,12 +101,12 @@ function convertBundleIntoReact(
   }
 
   const content: React.ReactNode[] = [];
-  const linkRegex = /(\s+|^)(https?:\/\/(?:www\.|(?!www))[^\s.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})(\s+|$)/g;
+  const linkRegex = /(\s+|^)(https?:\/\/(?:www\.|(?!www))[^\s.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})/g;
 
   let index = 0;
   let match: RegExpExecArray | null;
   while ((match = linkRegex.exec(bundle.content)) !== null) {
-    const [ , pre, url, post ] = match;
+    const [ , pre, url ] = match;
 
     const startIndex = match.index + pre.length;
     if (startIndex > index) {
@@ -128,8 +128,7 @@ function convertBundleIntoReact(
       )
     );
 
-    const endIndex = linkRegex.lastIndex - post.length;
-    index = endIndex;
+    index = linkRegex.lastIndex;
   }
 
   if (index < bundle.content.length) {


### PR DESCRIPTION
Whoops. #43 introduced a regression where, if multiple links are separated by only a single whitespace character (such as a newline), every other link is not linkified:

![image](https://user-images.githubusercontent.com/67761731/94320608-404e0200-ff42-11ea-82c9-0a5c9cb827df.png)

This is due to the regex consuming the whitespace on both sides of every link, so adjacent links would "fight" over a single space and only one would win.

The trailing whitespace actually does not need to be matched in the regex -- greediness will make sure the full link is matched. So this PR just removes the trailing whitespace part from that regex.