### PR TITLE
Add support to return a span element without a code wrap

### DIFF
--- a/__tests__/index.spec.tsx
+++ b/__tests__/index.spec.tsx
@@ -193,6 +193,21 @@ describe("Ansi", () => {
     );
   });
 
+  test("can spanify", () => {
+    const el = shallow(
+      React.createElement(
+        Ansi,
+        { spanify: true },
+        "spanify works"
+      )
+    );
+    expect(el).not.toBeNull();
+    expect(el.text()).toBe("spanify works");
+    expect(el.html()).toBe(
+      '<span>spanify works</span>'
+    );
+  });
+
   describe("useClasses options", () => {
     test("can add the font color class", () => {
       const el = shallow(

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,13 +143,16 @@ declare interface Props {
   linkify?: boolean;
   className?: string;
   useClasses?: boolean;
+  spanify?: boolean;
 }
 
 export default function Ansi(props: Props): JSX.Element {
-  const { className, useClasses, children, linkify } = props;
+  const { className, useClasses, children, linkify, spanify } = props;
+  const elementType = spanify ? React.Fragment : "code";
+  const elementProps = spanify ? null : { className };
   return React.createElement(
-    "code",
-    { className },
+    elementType,
+    elementProps,
     ansiToJSON(children ?? "", useClasses ?? false).map(
       convertBundleIntoReact.bind(null, linkify ?? false, useClasses ?? false)
     )


### PR DESCRIPTION
This PR adds a new prop called `spanify`, that indicates whether Ansi should return the span element without a code wrap. This helps to add support in returning different React element types.

