### PR TITLE
 fix: Catastrophic backtracking regex condition (#64)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ function convertBundleIntoReact(
   }
 
   const content: React.ReactNode[] = [];
-  const linkRegex = /(\s+|^)(https?:\/\/(?:www\.|(?!www))[^\s.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})/g;
+  const linkRegex = /(\s|^)(https?:\/\/(?:www\.|(?!www))[^\s.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})/g;
 
   let index = 0;
   let match: RegExpExecArray | null;


### PR DESCRIPTION
Fix for: https://github.com/nteract/ansi-to-react/issues/64

All current tests pass with the suggested new regex + performance/crash issue is resolved.

Unfortunately I don't think it's possible to test for a regex ReDoS since obviously everything crashes when it's triggered. 