### PR TITLE
Add support for React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "escape-carriage": "^1.3.0"
   },
   "peerDependencies": {
-    "react": "^16.3.2 || ^17.0.0",
-    "react-dom": "^16.3.2 || ^17.0.0"
+    "react": "^16.3.2 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.3.2 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@semantic-release/npm": "^7.0.8",


### PR DESCRIPTION
This is a simple PR to open peer dependencies to React 18. The package seems to work fine in React 18, it just complains about peer dependencies and requires a `npm install --force`, which is not ideal and causes problems (especially in monorepos) or brings in multiple versions of React.

See #80